### PR TITLE
Update ember-template-compiler dependency to support Ember 1.8 and newer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 gulp-ember-templates
 ====================
 
-Gulp plugin for compiling ember.js templates
+Gulp plugin for compiling ember.js templates.
+
+This plugin will compile templates for use in Ember 1.8 and newer. Use `gulp-ember-templates@0.5.2` to generate templates for Ember 1.7 and older.
 
 Usage
 ====================

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function compileTemplate (fileContents, done) {
     var compilerOutput;
         
     try {
-      compilerOutput = compiler.precompile(fileContents);
+      compilerOutput = compiler.precompile(fileContents, false);
     }
     catch (e) {
       return done(e);

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "through2": "~0.4.1",
     "gulp-util": "~2.2.14",
-    "handlebars": "~1.3.0",
-    "ember-template-compiler": "~1.6.0-beta.4",
+    "ember-template-compiler": "1.9.0-alpha",
     "merge": "~1.1.3",
     "async": "~0.9.0"
   },

--- a/test/expectations/amd/simple_custom_module_name_expectation.js
+++ b/test/expectations/amd/simple_custom_module_name_expectation.js
@@ -1,10 +1,4 @@
 define(["ember"], function (Ember) {
-Ember.TEMPLATES["custom/name/simple_fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["custom/name/simple_fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); });
+  },"useData":true}); });

--- a/test/expectations/amd/simple_custom_name_expectation.js
+++ b/test/expectations/amd/simple_custom_name_expectation.js
@@ -1,10 +1,4 @@
 define(["ember"], function (Ember) {
-Ember.TEMPLATES["templates/custom_name"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["templates/custom_name"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); });
+  },"useData":true}); });

--- a/test/expectations/amd/simple_expectation.js
+++ b/test/expectations/amd/simple_expectation.js
@@ -1,10 +1,4 @@
 define(["ember"], function (Ember) {
-Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); });
+  },"useData":true}); });

--- a/test/expectations/amd/simple_expectation_default_module_name.js
+++ b/test/expectations/amd/simple_expectation_default_module_name.js
@@ -1,10 +1,4 @@
 define(["ember"], function (Ember) {
-Ember.TEMPLATES["templates/simple_fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["templates/simple_fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); });
+  },"useData":true}); });

--- a/test/expectations/amd/simple_function_transformed_name_expectation.js
+++ b/test/expectations/amd/simple_function_transformed_name_expectation.js
@@ -1,10 +1,4 @@
 define(["ember"], function (Ember) {
-Ember.TEMPLATES["templates/fixture_simple"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["templates/fixture_simple"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); });
+  },"useData":true}); });

--- a/test/expectations/amd/simple_no_custom_module_name_expectation.js
+++ b/test/expectations/amd/simple_no_custom_module_name_expectation.js
@@ -1,10 +1,4 @@
 define(["ember"], function (Ember) {
-Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); });
+  },"useData":true}); });

--- a/test/expectations/amd/simple_regex_transformed_name_expectation.js
+++ b/test/expectations/amd/simple_regex_transformed_name_expectation.js
@@ -1,10 +1,4 @@
 define(["ember"], function (Ember) {
-Ember.TEMPLATES["templates/simple/fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["templates/simple/fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); });
+  },"useData":true}); });

--- a/test/expectations/browser/simple_custom_name_expectation.js
+++ b/test/expectations/browser/simple_custom_name_expectation.js
@@ -1,9 +1,3 @@
-Ember.TEMPLATES["custom_name"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["custom_name"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-});
+  },"useData":true});

--- a/test/expectations/browser/simple_expectation.js
+++ b/test/expectations/browser/simple_expectation.js
@@ -1,9 +1,3 @@
-Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-});
+  },"useData":true});

--- a/test/expectations/browser/simple_function_transformed_name_expectation.js
+++ b/test/expectations/browser/simple_function_transformed_name_expectation.js
@@ -1,9 +1,3 @@
-Ember.TEMPLATES["fixture_simple"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["fixture_simple"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-});
+  },"useData":true});

--- a/test/expectations/browser/simple_regex_transformed_name_expectation.js
+++ b/test/expectations/browser/simple_regex_transformed_name_expectation.js
@@ -1,9 +1,3 @@
-Ember.TEMPLATES["simple/fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+Ember.TEMPLATES["simple/fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-});
+  },"useData":true});

--- a/test/expectations/cjs/simple_custom_name_expectation.js
+++ b/test/expectations/cjs/simple_custom_name_expectation.js
@@ -1,9 +1,3 @@
-module.exports = Ember.TEMPLATES["custom_name"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+module.exports = Ember.TEMPLATES["custom_name"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-});
+  },"useData":true});

--- a/test/expectations/cjs/simple_expectation.js
+++ b/test/expectations/cjs/simple_expectation.js
@@ -1,9 +1,3 @@
-module.exports = Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+module.exports = Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-});
+  },"useData":true});

--- a/test/expectations/cjs/simple_function_transformed_name_expectation.js
+++ b/test/expectations/cjs/simple_function_transformed_name_expectation.js
@@ -1,9 +1,3 @@
-module.exports = Ember.TEMPLATES["fixture_simple"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+module.exports = Ember.TEMPLATES["fixture_simple"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-});
+  },"useData":true});

--- a/test/expectations/cjs/simple_regex_transformed_name_expectation.js
+++ b/test/expectations/cjs/simple_regex_transformed_name_expectation.js
@@ -1,9 +1,3 @@
-module.exports = Ember.TEMPLATES["simple/fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+module.exports = Ember.TEMPLATES["simple/fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-});
+  },"useData":true});

--- a/test/expectations/es6/simple_custom_name_expectation.js
+++ b/test/expectations/es6/simple_custom_name_expectation.js
@@ -1,9 +1,3 @@
-export default function () { return Ember.TEMPLATES["custom_name"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+export default function () { return Ember.TEMPLATES["custom_name"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); };
+  },"useData":true}); };

--- a/test/expectations/es6/simple_expectation.js
+++ b/test/expectations/es6/simple_expectation.js
@@ -1,9 +1,3 @@
-export default function () { return Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+export default function () { return Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); };
+  },"useData":true}); };

--- a/test/expectations/es6/simple_function_transformed_name_expectation.js
+++ b/test/expectations/es6/simple_function_transformed_name_expectation.js
@@ -1,9 +1,3 @@
-export default function () { return Ember.TEMPLATES["fixture_simple"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+export default function () { return Ember.TEMPLATES["fixture_simple"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); };
+  },"useData":true}); };

--- a/test/expectations/es6/simple_regex_transformed_name_expectation.js
+++ b/test/expectations/es6/simple_regex_transformed_name_expectation.js
@@ -1,9 +1,3 @@
-export default function () { return Ember.TEMPLATES["simple/fixture"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
-  
-
-
+export default function () { return Ember.TEMPLATES["simple/fixture"] = Ember.Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   data.buffer.push("A simple template");
-  
-}); };
+  },"useData":true}); };


### PR DESCRIPTION
Includes updated test expectations based on Handlebars 2.0 output and notice in README.md about which versions of the plugin to use for which version of Ember. I didn't update the plugin version number in package.json however.