### PR TITLE
Added the ability to use a custom compiler at call time

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install --save-dev gulp-ember-templates
 Then you can use the plugin in your ```gulpfile.js``` to output your templates
 in one the following formats
 
-###Browser Output
+### Browser Output
 
 ```javascript
 var gulp = require('gulp');
@@ -35,7 +35,7 @@ Note: ``` concat ``` is not mandatory, however this will produce a single file
 to reference in your html page. This must appear after the call to the 
 ``` gulp-ember-templates ```
 
-###AMD Output
+### AMD Output
 
 ```javascript
 var gulp = require('gulp');
@@ -50,7 +50,7 @@ gulp.task('default', function () {
 });
 ```
 
-###CJS Output
+### CJS Output
 
 ```javascript
 var gulp = require('gulp');
@@ -65,7 +65,7 @@ gulp.task('default', function () {
 });
 ```
 
-###ES6 Output
+### ES6 Output
 
 ```javascript
 var gulp = require('gulp');
@@ -83,7 +83,7 @@ gulp.task('default', function () {
 API Options
 ====================
 
-###options.type
+### options.type
 
 Type: ``` String ```,
 Default: ``` browser ```
@@ -94,7 +94,7 @@ This options specifies the output type that will be used. Available types
 * ``` cjs ``` - Output CJS modules
 * ``` es6 ``` - Output ES6 modules
 
-###options.moduleName
+### options.moduleName
 
 Type: ``` String ```,
 Default: ``` templates ```
@@ -105,7 +105,7 @@ when using the ``` options.type ``` of ``` amd ```
 Note: You can specify an empty string if you wish to use the template file name
 for the module name
 
-###options.name
+### options.name
 
 Type ``` String|Object|Function ```,
 Default: the template file name
@@ -113,7 +113,7 @@ Default: the template file name
 This option allows you to specify a fixed name or a transform to be used for 
 the template name
 
-####usages
+#### usages
 
 ```javascript
 var gulp = require('gulp');
@@ -154,6 +154,50 @@ gulp.task('default', function () {
         
         done(null, name);
       }
+    }))
+    .pipe(gulp.dest('./some/other/place'));
+});
+```
+
+### options.compiler
+
+Type: ``` Object ```,
+Default: ``` null ```
+
+This option allows you to specify a custom compiler to be used (e.g., the HTMLBars-flavored ember-compile-templates script bundled with Ember 1.10).
+
+#### usages
+
+```javascript
+var gulp = require('gulp');
+var emberTemplates = require('gulp-ember-templates');
+
+gulp.task('default', function() {
+  gulp.src('./some/place/*.handlebars')
+    .pipe(emberTemplates({
+      compiler: require('./bower_components/ember/ember-template-compiler'), // custom compiler object
+      isHTMLBars: true
+    }))
+    .pipe(gulp.dest('./some/other/place'));
+});
+```
+
+### options.isHTMLBars
+
+Type: ``` Boolean ```,
+Default: ``` false ```
+
+This option allows you to determine whether to use the `Ember.HTMLBars` or the `Ember.Handlebars` namespace in the generated template code.
+
+```javascript
+var gulp = require('gulp');
+var emberTemplates = require('gulp-ember-templates');
+
+gulp.task('default', function() {
+  gulp.src('./some/place/*.handlebars')
+    .pipe(emberTemplates({
+      compiler: require('./bower_components/ember/ember-template-compiler'),
+      isHTMLBars: true                                                       // generates Ember.HTMLBars.template( ... )
     }))
     .pipe(gulp.dest('./some/other/place'));
 });

--- a/README.md
+++ b/README.md
@@ -175,8 +175,7 @@ var emberTemplates = require('gulp-ember-templates');
 gulp.task('default', function() {
   gulp.src('./some/place/*.handlebars')
     .pipe(emberTemplates({
-      compiler: require('./bower_components/ember/ember-template-compiler'), // custom compiler object
-      isHTMLBars: true
+      compiler: require('./bower_components/ember/ember-template-compiler')
     }))
     .pipe(gulp.dest('./some/other/place'));
 });
@@ -189,6 +188,8 @@ Default: ``` false ```
 
 This option allows you to determine whether to use the `Ember.HTMLBars` or the `Ember.Handlebars` namespace in the generated template code.
 
+#### usages
+
 ```javascript
 var gulp = require('gulp');
 var emberTemplates = require('gulp-ember-templates');
@@ -197,7 +198,7 @@ gulp.task('default', function() {
   gulp.src('./some/place/*.handlebars')
     .pipe(emberTemplates({
       compiler: require('./bower_components/ember/ember-template-compiler'),
-      isHTMLBars: true                                                       // generates Ember.HTMLBars.template( ... )
+      isHTMLBars: true // Will generate `Ember.HTMLBars.template({ ... })`
     }))
     .pipe(gulp.dest('./some/other/place'));
 });

--- a/test/amd.test.js
+++ b/test/amd.test.js
@@ -87,4 +87,29 @@ describe('amd output', function () {
 
     test_helpers.assertAMDTemplate(options, expectedFileName, done);
   });
+
+  it('should compile templates with custom compiler', function (done) {
+    var expectedFileName = 'simple_custom_compiler_expectation.js';
+    var options = {
+      type: 'amd',
+      compiler: {
+        precompile: function() { return '/* noop */'; }
+      }
+    };
+
+    test_helpers.assertAMDTemplate(options, expectedFileName, done);
+  });
+
+  it('should compile templates with custom compiler (htmlbars flag on)', function (done) {
+    var expectedFileName = 'simple_custom_compiler_and_ishtmlbars_expectation.js';
+    var options = {
+      type: 'amd',
+      isHTMLBars: true,
+      compiler: {
+        precompile: function() { return '/* noop */'; }
+      }
+    };
+
+    test_helpers.assertAMDTemplate(options, expectedFileName, done);
+  });
 });

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -3,13 +3,13 @@ var test_helpers = require('./test-helpers');
 describe('browser output', function () {
   it('should compile templates', function (done) {
     var expectedFileName = 'simple_expectation.js';
-    var options = { 
-      type: 'browser' 
+    var options = {
+      type: 'browser'
     };
 
     test_helpers.assertBrowserTemplate(options, expectedFileName, done);
   });
-  
+
   it('should compile templates with no options specified', function (done) {
     var expectedFileName = 'simple_expectation.js';
 
@@ -19,16 +19,16 @@ describe('browser output', function () {
 
   it('should compile templates with custom name', function (done) {
     var expectedFileName = 'simple_custom_name_expectation.js';
-    var options = { 
+    var options = {
       name: 'custom_name'
     };
 
     test_helpers.assertBrowserTemplate(options, expectedFileName, done);
   });
-  
+
   it('should compile templates with a regex transformed name', function (done) {
     var expectedFileName = 'simple_regex_transformed_name_expectation.js';
-    var options = { 
+    var options = {
       name: {
         replace: /_/g,
         with: '/'
@@ -37,15 +37,38 @@ describe('browser output', function () {
 
     test_helpers.assertBrowserTemplate(options, expectedFileName, done);
   });
-  
+
   it('should compile templates with a function transformed name', function (done) {
     var expectedFileName = 'simple_function_transformed_name_expectation.js';
-    var options = { 
+    var options = {
       name: function (name, done) {
         var parts = name.split('_');
         var transformedName = parts[1] + '_' + parts[0];
 
         done(null, transformedName);
+      }
+    };
+
+    test_helpers.assertBrowserTemplate(options, expectedFileName, done);
+  });
+
+  it('should compile templates with custom compiler', function (done) {
+    var expectedFileName = 'simple_custom_compiler_expectation.js';
+    var options = {
+      compiler: {
+        precompile: function() { return '/* noop */'; }
+      }
+    };
+
+    test_helpers.assertBrowserTemplate(options, expectedFileName, done);
+  });
+
+  it('should compile templates with custom compiler (htmlbars flag on)', function (done) {
+    var expectedFileName = 'simple_custom_compiler_and_ishtmlbars_expectation.js';
+    var options = {
+      isHTMLBars: true,
+      compiler: {
+        precompile: function() { return '/* noop */'; }
       }
     };
 

--- a/test/cjs.test.js
+++ b/test/cjs.test.js
@@ -47,4 +47,29 @@ describe('cjs output', function () {
 
     test_helpers.assertCJSTemplate(options, expectedFileName, done);
   });
+
+  it('should compile templates with custom compiler', function (done) {
+    var expectedFileName = 'simple_custom_compiler_expectation.js';
+    var options = {
+      type: 'cjs',
+      compiler: {
+        precompile: function() { return '/* noop */'; }
+      }
+    };
+
+    test_helpers.assertCJSTemplate(options, expectedFileName, done);
+  });
+
+  it('should compile templates with custom compiler (htmlbars flag on)', function (done) {
+    var expectedFileName = 'simple_custom_compiler_and_ishtmlbars_expectation.js';
+    var options = {
+      type: 'cjs',
+      isHTMLBars: true,
+      compiler: {
+        precompile: function() { return '/* noop */'; }
+      }
+    };
+
+    test_helpers.assertCJSTemplate(options, expectedFileName, done);
+  });
 });

--- a/test/es6.test.js
+++ b/test/es6.test.js
@@ -47,4 +47,29 @@ describe('es6 output', function () {
 
     test_helpers.assertES6Template(options, expectedFileName, done);
   });
+
+  it('should compile templates with custom compiler', function (done) {
+    var expectedFileName = 'simple_custom_compiler_expectation.js';
+    var options = {
+      type: 'es6',
+      compiler: {
+        precompile: function() { return '/* noop */'; }
+      }
+    };
+
+    test_helpers.assertES6Template(options, expectedFileName, done);
+  });
+
+  it('should compile templates with custom compiler (htmlbars flag on)', function (done) {
+    var expectedFileName = 'simple_custom_compiler_and_ishtmlbars_expectation.js';
+    var options = {
+      type: 'es6',
+      isHTMLBars: true,
+      compiler: {
+        precompile: function() { return '/* noop */'; }
+      }
+    };
+
+    test_helpers.assertES6Template(options, expectedFileName, done);
+  });
 });

--- a/test/expectations/amd/simple_custom_compiler_and_ishtmlbars_expectation.js
+++ b/test/expectations/amd/simple_custom_compiler_and_ishtmlbars_expectation.js
@@ -1,0 +1,2 @@
+define(["ember"], function (Ember) {
+Ember.TEMPLATES["templates/simple_fixture"] = Ember.HTMLBars.template(/* noop */); });

--- a/test/expectations/amd/simple_custom_compiler_expectation.js
+++ b/test/expectations/amd/simple_custom_compiler_expectation.js
@@ -1,0 +1,2 @@
+define(["ember"], function (Ember) {
+Ember.TEMPLATES["templates/simple_fixture"] = Ember.Handlebars.template(/* noop */); });

--- a/test/expectations/browser/simple_custom_compiler_and_ishtmlbars_expectation.js
+++ b/test/expectations/browser/simple_custom_compiler_and_ishtmlbars_expectation.js
@@ -1,0 +1,1 @@
+Ember.TEMPLATES["simple_fixture"] = Ember.HTMLBars.template(/* noop */);

--- a/test/expectations/browser/simple_custom_compiler_expectation.js
+++ b/test/expectations/browser/simple_custom_compiler_expectation.js
@@ -1,0 +1,1 @@
+Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template(/* noop */);

--- a/test/expectations/cjs/simple_custom_compiler_and_ishtmlbars_expectation.js
+++ b/test/expectations/cjs/simple_custom_compiler_and_ishtmlbars_expectation.js
@@ -1,0 +1,1 @@
+module.exports = Ember.TEMPLATES["simple_fixture"] = Ember.HTMLBars.template(/* noop */);

--- a/test/expectations/cjs/simple_custom_compiler_expectation.js
+++ b/test/expectations/cjs/simple_custom_compiler_expectation.js
@@ -1,0 +1,1 @@
+module.exports = Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template(/* noop */);

--- a/test/expectations/es6/simple_custom_compiler_and_ishtmlbars_expectation.js
+++ b/test/expectations/es6/simple_custom_compiler_and_ishtmlbars_expectation.js
@@ -1,0 +1,1 @@
+export default function () { return Ember.TEMPLATES["simple_fixture"] = Ember.HTMLBars.template(/* noop */); };

--- a/test/expectations/es6/simple_custom_compiler_expectation.js
+++ b/test/expectations/es6/simple_custom_compiler_expectation.js
@@ -1,0 +1,1 @@
+export default function () { return Ember.TEMPLATES["simple_fixture"] = Ember.Handlebars.template(/* noop */); };


### PR DESCRIPTION
I made this change because I'm using Ember 1.10, which ships with HTMLBars instead of Handlebars[1] and my app was busted.

This is based on a local change I made which fixed my problem.  I figure this should tide folks over until ember-template-compiler stabilizes.

I also added tests covering the additional options and updated the README both to add the new options and to fix the styling for the plugin's NPM package site (https://www.npmjs.com/package/gulp-ember-templates).

[1] http://emberjs.com/blog/2015/02/05/compiling-templates-in-1-10-0.html