### PR TITLE
Added precompile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,10 @@ gulp.task('default', function() {
     .pipe(gulp.dest('./some/other/place'));
 });
 ```
+
+### options.precompile
+
+Type: ``` Boolean ```,
+Default: ``` true ```
+
+Disable this option to skip template precompilation and instead wrap the template content with Ember.HTMLBars.compile. This will reduce template compilation time during development. Don't disable this option for production build.


### PR DESCRIPTION
When set to false, `precompile` option wraps the templates in compile function to speed up the build (must have `ember-template-compiler` script included in page). Only recommended for development builds.
Similar to grunt-ember-compiler precompile option: https://www.npmjs.com/package/grunt-ember-templates#precompile
