### PR TITLE
Using full name for transformedName if component is in the string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var formats = {
 };
 
 function transformName (name, options, done) {
-  var transformedName = name.split('/').slice(-1)[0].toString();
+  var transformedName = name.startsWith('component/') ? name : name.split('/').slice(-1)[0].toString();
 
   if (options.name) {
     switch (typeof options.name)


### PR DESCRIPTION
Using full name for transformedName if component is in the string. Otherwise, keeping the split.
